### PR TITLE
add a parameter to "yes_it_shipped" assertion to overwrite the default

### DIFF
--- a/assertions/yes_it_shipped.rb
+++ b/assertions/yes_it_shipped.rb
@@ -2,13 +2,15 @@ module YSI
   class YesItShipped < Assertion
     needs "tag"
 
+    parameter :yis_server_url, "https://yes-it-shipped.herokuapp.com"
+
     def self.display_name
       "pushed to yes-it-shipped"
     end
 
     def check
       begin
-        RestClient.get("https://yes-it-shipped.herokuapp.com/releases/#{engine.project_name}/#{engine.version}")
+        RestClient.get("#{yis_server_url}/releases/#{engine.project_name}/#{engine.version}")
         return "#{engine.project_name}-#{engine.version}"
       rescue RestClient::ResourceNotFound
         return nil
@@ -16,7 +18,7 @@ module YSI
     end
 
     def assert(executor)
-      executor.http_post("https://yes-it-shipped.herokuapp.com/releases",
+      executor.http_post("#{yis_server_url}/releases",
         project: engine.project_name, version: engine.version,
         release_date_time: engine.tag_date, project_url: engine.project_url,
         release_url: engine.release_url, ysi_config_url: engine.config_url)

--- a/spec/unit/assertions/yes_it_shipped_spec.rb
+++ b/spec/unit/assertions/yes_it_shipped_spec.rb
@@ -71,4 +71,26 @@ EOT
       expect(assertion.assert(engine.executor)).to eq("dummy-1.1.1")
     end
   end
+  it "reads yis_server_url parameter" do
+    config = <<EOT
+assertions:
+  yes_it_shipped:
+    yis_server_url: http://localhost:3000
+EOT
+    engine = YSI::Engine.new
+    engine.read_config(config)
+
+    expect(engine.assertions.first.yis_server_url).to eq("http://localhost:3000")
+  end
+  it "has default yis_server_url parameter" do
+    config = <<EOT
+assertions:
+  yes_it_shipped:
+EOT
+    engine = YSI::Engine.new
+    engine.read_config(config)
+
+    expect(engine.assertions.first.yis_server_url).to eq("https://yes-it-shipped.herokuapp.com")
+  end
+
 end


### PR DESCRIPTION
server

This fixes #27

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>